### PR TITLE
fix: safe no-op stubs in FakeUserDao (remove crashing TODOs)

### DIFF
--- a/login/src/main/java/com/mito/login/ui/LoginScreen.kt
+++ b/login/src/main/java/com/mito/login/ui/LoginScreen.kt
@@ -68,6 +68,7 @@ import com.mito.network.auth.data.LoginService
 import com.mito.network.auth.data.request.LoginRequest
 import com.mito.network.auth.data.response.LoginResponse
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import retrofit2.Response
 import kotlin.system.exitProcess
 
@@ -333,23 +334,13 @@ class FakeLoginService : LoginService {
 }
 
 object FakeUserDao : UserDao {
-    override fun getAll(): Flow<List<UserEntity>> {
-        TODO("Not yet implemented")
-    }
+    override fun getAll(): Flow<List<UserEntity>> = flowOf(emptyList())
 
-    override suspend fun getUserId(email: String, password: String): Int? {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getUserId(email: String, password: String): Int? = null
 
-    override suspend fun insert(user: UserEntity) {
-        TODO("Not yet implemented")
-    }
+    override suspend fun insert(user: UserEntity) = Unit
 
-    override suspend fun update(user: UserEntity) {
-        TODO("Not yet implemented")
-    }
+    override suspend fun update(user: UserEntity) = Unit
 
-    override suspend fun delete(user: UserEntity) {
-        TODO("Not yet implemented")
-    }
+    override suspend fun delete(user: UserEntity) = Unit
 }


### PR DESCRIPTION
Criterio: tarea critica. Los 5 metodos de FakeUserDao lanzaban TODO("Not yet implemented") que crashearian la app si se usan en previews. Reemplazados por stubs seguros (flowOf(emptyList()), null, Unit). Sin cambios de firma ni funcionalidad.