### PR TITLE
refactor: move shared UI resources to components module

### DIFF
--- a/libs/components/src/main/java/com/mito/components/resources/PaddingValues.kt
+++ b/libs/components/src/main/java/com/mito/components/resources/PaddingValues.kt
@@ -1,4 +1,4 @@
-package com.mito.login.ui.tools
+package com.mito.components.resources
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding

--- a/libs/components/src/main/java/com/mito/components/resources/Type.kt
+++ b/libs/components/src/main/java/com/mito/components/resources/Type.kt
@@ -1,4 +1,4 @@
-package com.mito.login.ui.tools
+package com.mito.components.resources
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
@@ -11,5 +11,6 @@ val headerTextHomeScreen = Typography(
         fontFamily = FontFamily.Monospace,
         fontWeight = FontWeight.SemiBold,
         fontSize = 25.sp,
-        letterSpacing = 3.sp)
+        letterSpacing = 3.sp
+    )
 )

--- a/login/src/main/java/com/mito/login/ui/WelcomeScreen.kt
+++ b/login/src/main/java/com/mito/login/ui/WelcomeScreen.kt
@@ -49,8 +49,8 @@ import com.mito.components.resources.content_color_disabled
 import com.mito.core.navigation.AppInfo
 import com.mito.core.navigation.Screen
 import com.mito.login.R
-import com.mito.login.ui.tools.headerTextHomeScreen
-import com.mito.login.ui.tools.paddingDefault
+import com.mito.components.resources.headerTextHomeScreen
+import com.mito.components.resources.paddingDefault
 
 class WelcomeScreen : Screen {
     override val route: String = NavigationReferences.WelcomeReference.getRoute()


### PR DESCRIPTION
headerTextHomeScreen (Type.kt) y paddingDefault (PaddingValues.kt) son recursos de UI compartidos. Se mueven de com.mito.login.ui.tools a libs.components.resources para reutilizacion centralizada, eliminando el paquete tools de login. WelcomeScreen actualiza sus imports. Sin cambios de funcionalidad.